### PR TITLE
Handle missing bank bag constants gracefully

### DIFF
--- a/AdiBags/core/Constants.lua
+++ b/AdiBags/core/Constants.lua
@@ -37,10 +37,13 @@ local BACKPACK_CONTAINER = _G.BACKPACK_CONTAINER or ( Enum.BagIndex and Enum.Bag
 local REAGENTBAG_CONTAINER = ( Enum.BagIndex and Enum.BagIndex.REAGENTBAG_CONTAINER ) or 5
 local BANK_CONTAINER = _G.BANK_CONTAINER or ( Enum.BagIndex and Enum.BagIndex.Bank ) or -1
 local REAGENTBANK_CONTAINER = _G.REAGENTBANK_CONTAINER or ( Enum.BagIndex and Enum.BagIndex.Reagentbank ) or -3
-local NUM_BAG_SLOTS = _G.NUM_BAG_SLOTS
-local NUM_REAGENTBAG_SLOTS = _G.NUM_REAGENTBAG_SLOTS
-local NUM_TOTAL_EQUIPPED_BAG_SLOTS = _G.NUM_TOTAL_EQUIPPED_BAG_SLOTS
-local NUM_BANKBAGSLOTS = _G.NUM_BANKBAGSLOTS
+-- Use sane fallbacks when running on clients where these globals are not
+-- defined.  This prevents runtime errors when the game API does not expose
+-- the constants (for instance on older or specialized client builds).
+local NUM_BAG_SLOTS = _G.NUM_BAG_SLOTS or 4
+local NUM_REAGENTBAG_SLOTS = _G.NUM_REAGENTBAG_SLOTS or 0
+local NUM_TOTAL_EQUIPPED_BAG_SLOTS = _G.NUM_TOTAL_EQUIPPED_BAG_SLOTS or (NUM_BAG_SLOTS + NUM_REAGENTBAG_SLOTS)
+local NUM_BANKBAGSLOTS = _G.NUM_BANKBAGSLOTS or 0
 local TRADE_GOODS = _G.Enum.ItemClass.Tradegoods
 local GetItemSubClassInfo = _G.C_Item.GetItemSubClassInfo
 local pairs = _G.pairs

--- a/AdiBags/core/Hooks.lua
+++ b/AdiBags/core/Hooks.lua
@@ -31,10 +31,12 @@ local REAGENTBAG_CONTAINER = ( Enum.BagIndex and Enum.BagIndex.REAGENTBAG_CONTAI
 local ContainerFrame_GenerateFrame = _G.ContainerFrame_GenerateFrame
 local ContainerFrame_GetOpenFrame = _G.ContainerFrame_GetOpenFrame
 local GetContainerNumSlots = C_Container and _G.C_Container.GetContainerNumSlots or _G.GetContainerNumSlots
-local NUM_BAG_SLOTS = _G.NUM_BAG_SLOTS
-local NUM_REAGENTBAG_SLOTS = _G.NUM_REAGENTBAG_SLOTS
-local NUM_TOTAL_EQUIPPED_BAG_SLOTS = _G.NUM_TOTAL_EQUIPPED_BAG_SLOTS
-local NUM_BANKBAGSLOTS = _G.NUM_BANKBAGSLOTS
+-- Provide fallbacks when global constants are missing to avoid arithmetic on
+-- nil values on clients with a reduced API surface.
+local NUM_BAG_SLOTS = _G.NUM_BAG_SLOTS or 4
+local NUM_REAGENTBAG_SLOTS = _G.NUM_REAGENTBAG_SLOTS or 0
+local NUM_TOTAL_EQUIPPED_BAG_SLOTS = _G.NUM_TOTAL_EQUIPPED_BAG_SLOTS or (NUM_BAG_SLOTS + NUM_REAGENTBAG_SLOTS)
+local NUM_BANKBAGSLOTS = _G.NUM_BANKBAGSLOTS or 0
 local NUM_CONTAINER_FRAMES = _G.NUM_CONTAINER_FRAMES
 local pairs = _G.pairs
 --GLOBALS>


### PR DESCRIPTION
## Summary
- use default values for bag-related constants when game API lacks them

## Testing
- `luac -p AdiBags/core/Constants.lua AdiBags/core/Hooks.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c6655b4c4832b85b96d347460cdda