### PR TITLE
chore: update TOC for 11.0.2

### DIFF
--- a/AdiBags/AdiBags.toc
+++ b/AdiBags/AdiBags.toc
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with AdiBags.  If not, see <http://www.gnu.org/licenses/>.
 
-## Interface: 110002
+## Interface: 110200
 
 ## Title: AdiBags
 ## Notes: Adirelle's bag addon.

--- a/AdiBags_Config/AdiBags_Config.toc
+++ b/AdiBags_Config/AdiBags_Config.toc
@@ -1,4 +1,4 @@
-## Interface: 110002
+## Interface: 110200
 
 ## Title: AdiBags Configuration
 ## Notes: Adirelle's bag addon.


### PR DESCRIPTION
## Summary
- bump main addon TOC to Interface 110200 for War Within patch 11.0.2
- update configuration module TOC to match interface 110200

## Testing
- `npm test` *(fails: could not read package.json)*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689c7e9ce89c832b89ea9861cdd3b249